### PR TITLE
Fix busy loop in reaping zombies

### DIFF
--- a/main.c
+++ b/main.c
@@ -253,8 +253,7 @@ int reap(const pid_t child_pid, int *child_exitcode_ptr) {
 	int reaped_status = 0;
 
 	while (1) {
-		reaped_pid = waitpid(-1, &reaped_status, WNOHANG);
-
+		reaped_pid = waitpid(-1, &reaped_status, 0);
 		switch (reaped_pid) {
 		case -1:
 			if (errno == ECHILD) {


### PR DESCRIPTION
We were using WNOHANG in waitpid and as a result, we were immediately returning from waitpid and then doing the same thing over and over again in a busy loop. As a result, we were consuming unnecessary CPU cycles.

Therefore, remove WNOHANG to avoid consuming CPU cycles.