### PR TITLE
Add support for reading and mounting block devices from the configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The key features of `urunit` are:
   is set.
 - Reading and setting the environment variables for an application from a file.
 - Reading and setting the execution environment configuration for a process from a file.
+- Reading and mounting attached block devices defined in the configuration file.
 
 ## Building
 
@@ -68,7 +69,9 @@ accepts a specific configuration file. The configuration file can contain the
 following information:
 
 - The list of the environment variables to set for the application
-- The configuration for the process configuration.
+- The configuration for the process execution environment.
+- The list of mounts of block devices. Each block device is defined by its
+  serial id and it will get mounted in the defined mountpoint.
 
 The file can be specified to `urunit` setting the `URUNIT_CONFIG`
 environment variable with the path to the configuration file.
@@ -84,6 +87,11 @@ UID: <uid_for_the_application>
 GID: <gid_for_the_application>
 WD:  <working_directory>
 UCE
+UBS
+ID: <serial_id>
+MP: <mountpoint>
+...
+UBE
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ to the target application.
 
 The key features of `urunit` are:
 
-- Parsing and grouping multi-word arguments from Linux kernel boot parameters
-- Launching and waiting for the target application until it terminates
-- Reaping all zombie processes
+- Parsing and grouping multi-word arguments from Linux kernel boot parameters.
+- Launching and waiting for the target application until it terminates.
+- Reaping all zombie processes.
+- Setting the default route to eth0, if `URUNIT_DEFROUTE` environment variable
+  is set.
+- Reading and setting the environment variables for an application from a file.
+- Reading and setting the execution environment configuration for a process from a file.
 
 ## Building
 
@@ -56,6 +60,31 @@ urunit echo `hello world`
 ```
 
 will result in `echo` receiving a single argument: `hello world`.
+
+### Urunit configuration file
+
+In order to configure the execution environment for an application, `urunit`
+accepts a specific configuration file. The configuration file can contain the
+following information:
+
+- The list of the environment variables to set for the application
+- The configuration for the process configuration.
+
+The file can be specified to `urunit` setting the `URUNIT_CONFIG`
+environment variable with the path to the configuration file.
+
+The supported format of the configuration file is the following:
+
+```
+UES
+/* list of environment variables */
+UEE
+UCS
+UID: <uid_for_the_application>
+GID: <gid_for_the_application>
+WD:  <working_directory>
+UCE
+```
 
 ## Installation
 


### PR DESCRIPTION
Add support for reading the list of block devices that should be mounted before the execution of the application. The list is tored in the configuration file with the following format:
```
UBS
ID: <serial_id>
MP: <mountpoint>
...
UBE
```

Given such a list, `urunit` for each pair of serial id and mountpoint will search all virtio block devices (vd[a-z]) and compare the serial IDs. If they match, `urunit` will create all necessary directories for the mountpoint and mount the device in the given mountpoint.

It is important to note, that the current approach assumes that all block devices will be virtio-based (since `urunc` uses only virtIO for block devices) and there are no more than 26 devices (a-z). However, the current approach is easily extensible for more devices.

At last, in case of a failure all created directories will get removed and before shutting down, `urunit` will unmount all mounted filesystems with an external source. External means a source outside of the VM (e.g. block, network). 